### PR TITLE
Fix for issue where, in formulas, HP and MP Regeneration would round …

### DIFF
--- a/RogueCustomsGameLogic/Utils/Helpers/ActionHelpers.cs
+++ b/RogueCustomsGameLogic/Utils/Helpers/ActionHelpers.cs
@@ -404,7 +404,7 @@ namespace RogueCustomsGameEngine.Utils.Helpers
                 }
                 else
                 {
-                    return decimalValue.ToString("F2", CultureInfo.GetCultureInfo("en-US"));
+                    return decimalValue.ToString("F5", CultureInfo.GetCultureInfo("en-US"));
                 }
             }
             else


### PR DESCRIPTION
…down to two decimals instead of using all of them.